### PR TITLE
Fix snippet of default configuration

### DIFF
--- a/src/Braincrafted/Bundle/BootstrapDemoBundle/Resources/views/Documentation/getting-started_configuration.html.twig
+++ b/src/Braincrafted/Bundle/BootstrapDemoBundle/Resources/views/Documentation/getting-started_configuration.html.twig
@@ -22,9 +22,10 @@ braincrafted_bootstrap:
     customize:
         variables_file: ~
         bootstrap_output: %kernel.root_dir%/Resources/less/bootstrap.less
-        bootstrap_template: BraincraftedBootstrapBundle:Bootstrap:bootstrap.less.twig</code></pre>
+        bootstrap_template: BraincraftedBootstrapBundle:Bootstrap:bootstrap.less.twig
     icon_prefix: glyphicon
     fontawesome_dir: %kernel.root_dir%/../vendor/fortawesome/font-awesome
+    </code></pre>
 
     <p>The option <code>braincrafted_bootstrap.output_dir</code> defines the directory where BootstrapBundle puts the Bootstrap asset files. This directory has to be relative to the Assetic output directory (configured with the <code>assetic.write_to</code> option). For example, if you want to have the Bootstrap assets in <code>web/bootstrap/(css|js)</code> set <code>braincrafted_bootstrap.output_dir</code> to <code>bootstrap</code>.</p>
 


### PR DESCRIPTION
Two lines where out of  the `<pre><code>` block of the example app/config/config.yml snippet.
